### PR TITLE
Making the static mask method public

### DIFF
--- a/src/main/java/ph/samson/logback/luhn/LuhnMaskingConverter.java
+++ b/src/main/java/ph/samson/logback/luhn/LuhnMaskingConverter.java
@@ -63,7 +63,7 @@ public class LuhnMaskingConverter extends ClassicConverter {
         return mask(e.getFormattedMessage());
     }
 
-    static String mask(String formattedMessage) {
+    public static String mask(String formattedMessage) {
         if (!hasEnoughDigits(formattedMessage)) {
             return formattedMessage;
         }


### PR DESCRIPTION
It's a useful method, and it's static so no issues with encapsulation :)
