### PR TITLE
Update logback version to 1.2.x - CVE-2017-5929

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven, just add it to your runtime dependencies:
     <dependency>
         <groupId>ph.samson.logback</groupId>
         <artifactId>logback-luhn-mask</artifactId>
-        <version>1.0</version>
+        <version>1.0.2</version>
         <scope>runtime</scope>
     </dependency>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logback Luhn Mask
 
-[![Build Status](https://buildhive.cloudbees.com/job/esamson/job/logback-luhn-mask/badge/icon)](https://buildhive.cloudbees.com/job/esamson/job/logback-luhn-mask/)
+[![Release](https://jitpack.io/v/com.github.paymaya/logback-luhn-mask.svg)](https://jitpack.io/#com.github.paymaya/logback-luhn-mask)
 
 This is a [Logback Converter](http://logback.qos.ch/manual/layouts.html#customConversionSpecifier)
 that masks any possible credit card numbers in your log messages.

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
         <version>2</version>
     </parent>
 
+    <properties>
+        <logback.version>1.2.3</logback.version>
+    </properties>
+
     <groupId>ph.samson.logback</groupId>
     <artifactId>logback-luhn-mask</artifactId>
     <version>1.0.2-SNAPSHOT</version>
@@ -36,13 +40,13 @@
         <developerConnection>scm:git:git@github.com:esamson/logback-luhn-mask.git</developerConnection>
         <url>https://github.com/esamson/logback-luhn-mask</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.10</version>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This will address the CVE-2017-5929 issue for logback before v.1.2.x .